### PR TITLE
Fix lint error and further improve the leave script

### DIFF
--- a/scripts/byephil.coffee
+++ b/scripts/byephil.coffee
@@ -26,7 +26,7 @@ module.exports = (robot) ->
   robot.respond /how long until phil leaves/i, (msg) ->
     msg.send getResponse()
 
-  robot.hear /how long until i leave/, (msg) ->
+  robot.hear /how long until i leave/i, (msg) ->
     if msg.message.user.name == 'Phil Booth'
       msg.send getResonse()
     else

--- a/scripts/byephil.coffee
+++ b/scripts/byephil.coffee
@@ -21,7 +21,7 @@ periods = {
 }
 
 endOfPhil = (new Date '2015-06-23T17:00:00+01:00').getTime()
-  
+
 module.exports = (robot) ->
   robot.respond /how long until phil leaves/i, (msg) ->
     msg.send getResponse()

--- a/scripts/byephil.coffee
+++ b/scripts/byephil.coffee
@@ -33,8 +33,7 @@ module.exports = (robot) ->
       msg.send 'No idea, mate.'
 
 getResponse = ->
-  time = (new Date()).getTime()
-  mapTime time
+  mapTime Date.now()
 
 mapTime = (date) ->
   difference = endOfPhil - date

--- a/scripts/byephil.coffee
+++ b/scripts/byephil.coffee
@@ -35,22 +35,22 @@ module.exports = (robot) ->
 getResponse = ->
   mapTime Date.now()
 
-mapTime = (date) ->
-  difference = endOfPhil - date
+mapTime = (time) ->
+  difference = endOfPhil - time
 
-  if difference <= minute
-    return "He's gone!"
+  if difference > week
+    return "Well this sucks, Pb. You're stuck here for #{formatTime difference, 'week'}. :("
 
-  if difference < hour
-    return "Start packing, Pb! Only #{formatTime difference, 'minute'} left!"
-
-  if difference < day
-    return "Delete the incriminating data, Pb! There's only #{formatTime difference, 'hour'} to go!"
-
-  if difference < week
+  if difference > day
     return "Put your feet up, Pb! You're officially chilling for #{formatTime difference, 'day'}!"
 
-  return "Well this sucks, Pb. You're stuck here for #{formatTime difference, 'week'}. :("
+  if difference > hour
+    return "Delete the incriminating data, Pb! There's only #{formatTime difference, 'hour'} to go!"
+
+  if difference > minute
+    return "Start packing, Pb! Only #{formatTime difference, 'minute'} left!"
+
+  "He's gone!"
 
 formatTime = (difference, period) ->
   periodCount = Math.round difference / periods[period]

--- a/scripts/leave.coffee
+++ b/scripts/leave.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   Ask hubot how long until Phil's notice period is served
+#   Ask hubot how long until someone's notice period is served
 #
 # Commands:
 #   hubot how long until phil leaves?

--- a/scripts/leave.coffee
+++ b/scripts/leave.coffee
@@ -38,6 +38,9 @@ getResponse = ->
 mapTime = (time) ->
   difference = endOfPhil - time
 
+  if difference < minute
+    return "He's gone!"
+
   if difference > week
     return "Well this sucks, Pb. You're stuck here for #{formatTime difference, 'week'}. :("
 
@@ -47,10 +50,7 @@ mapTime = (time) ->
   if difference > hour
     return "Delete the incriminating data, Pb! There's only #{formatTime difference, 'hour'} to go!"
 
-  if difference > minute
-    return "Start packing, Pb! Only #{formatTime difference, 'minute'} left!"
-
-  "He's gone!"
+  "Start packing, Pb! Only #{formatTime difference, 'minute'} left!"
 
 formatTime = (difference, period) ->
   periodCount = Math.round difference / periods[period]

--- a/scripts/leave.coffee
+++ b/scripts/leave.coffee
@@ -22,35 +22,40 @@ periods = {
 
 endOfPhil = (new Date '2015-06-23T17:00:00+01:00').getTime()
 
+nicknames =
+  'Phil Booth': 'Pb'
+
 module.exports = (robot) ->
+  name = msg.message.user.name
+
   robot.respond /how long until phil leaves/i, (msg) ->
-    msg.send getResponse()
+    msg.send getResponse name
 
   robot.hear /how long until i leave/i, (msg) ->
-    if msg.message.user.name == 'Phil Booth'
-      msg.send getResonse()
+    if name == 'Phil Booth'
+      msg.send getResonse name
     else
       msg.send 'No idea, mate.'
 
-getResponse = ->
-  mapTime Date.now()
+getResponse = (name) ->
+  mapTime Date.now(), nicknames[name] || user
 
-mapTime = (time) ->
+mapTime = (time, name) ->
   difference = endOfPhil - time
 
   if difference < minute
-    return "He's gone!"
+    return "#{name}'s gone!"
 
   if difference > week
-    return "Well this sucks, Pb. You're stuck here for #{formatTime difference, 'week'}. :("
+    return "Well this sucks, #{name}. You're stuck here for #{formatTime difference, 'week'}. :("
 
   if difference > day
-    return "Put your feet up, Pb! You're officially chilling for #{formatTime difference, 'day'}!"
+    return "Put your feet up, #{name}! You're officially chilling for #{formatTime difference, 'day'}!"
 
   if difference > hour
-    return "Delete the incriminating data, Pb! There's only #{formatTime difference, 'hour'} to go!"
+    return "Delete the incriminating data, #{name}! There's only #{formatTime difference, 'hour'} to go!"
 
-  "Start packing, Pb! Only #{formatTime difference, 'minute'} left!"
+  "Start packing, #{name}! Only #{formatTime difference, 'minute'} left!"
 
 formatTime = (difference, period) ->
   periodCount = Math.round difference / periods[period]


### PR DESCRIPTION
Although I tested `byephil` yesterday, I didn't lint it. Hence it failed to deploy, sorry.

While fixing that bug, I also made the following improvements to the script:

* Renamed it to `leave.coffee` and made it generic in the expectation that future leavers may want to add their own details to the script.
* Made the `how long until i leave` regex case-insensitive.
* Improved the performance of `mapTime` by running the most common conditions first.
* Eliminated an unnecessary call to the `Date` constructor.